### PR TITLE
fix: Correct async declaration for handleFormSubmit

### DIFF
--- a/script.js
+++ b/script.js
@@ -123,7 +123,7 @@ function attachEventListenersToButtons() {
 
 // showJsonForSaving function is completely removed.
 
-function handleFormSubmit(event) {
+async function handleFormSubmit(event) {
     event.preventDefault();
 
     if (!nameInput.value.trim() || !w3wInput.value.trim()) {


### PR DESCRIPTION
Resolved a SyntaxError caused by using 'await' inside 'handleFormSubmit' without declaring the function as 'async'. This change ensures that Supabase calls within your form submission process are handled correctly.