### PR TITLE
fix: Restore modal HTML structure and verify element IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fruit & Herb Tracker</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- ADD FONT AWESOME CDN -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -18,7 +17,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav ms-auto"> <!-- ms-auto pushes to the right -->
+                <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
                         <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#plantFormModal">
                             <i class="fas fa-plus"></i> Add New Plant
@@ -39,10 +38,64 @@
                 </div>
             </div>
         </div>
+    </div>
 
-        <hr class="my-4">
-
-        <!-- Save Data section removed -->
+    <!-- Add/Edit Plant Modal -->
+    <div class="modal fade" id="plantFormModal" tabindex="-1" aria-labelledby="formTitle" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <!-- Form tag now wraps modal-header, modal-body, and modal-footer to ensure submit button works -->
+                <form id="plantForm">
+                    <div class="modal-header">
+                        <!-- The H2 with id="formTitle" is moved here -->
+                        <h2 class="modal-title fs-5" id="formTitle">Add New Plant</h2>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <!-- The entire form content (excluding the old h2 and submit button) is moved here -->
+                        <input type="hidden" id="plantId">
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Name</label>
+                            <input type="text" class="form-control" id="name" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="type" class="form-label">Type</label>
+                            <select class="form-select" id="type" required>
+                                <option value="Fruit Tree">Fruit Tree</option>
+                                <option value="Herb">Herb</option>
+                                <option value="Other">Other</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="w3w" class="form-label">What3Words Address</label>
+                            <div class="input-group">
+                                <input type="text" class="form-control" id="w3w" placeholder="e.g. filled.count.soap" required>
+                                <button class="btn btn-outline-secondary" type="button" id="getW3wLocationBtn" title="Get current location as What3Words">
+                                    <i class="fas fa-map-marker-alt"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="ripens" class="form-label">Ripens</label>
+                            <input type="text" class="form-control" id="ripens" placeholder="e.g. Late Summer, Year-round">
+                        </div>
+                        <div class="mb-3">
+                            <label for="harvestMonth" class="form-label">Best Harvest Month</label>
+                            <input type="text" class="form-control" id="harvestMonth" placeholder="e.g. September, June">
+                        </div>
+                        <div class="mb-3">
+                            <label for="notes" class="form-label">Notes</label>
+                            <textarea class="form-control" id="notes" rows="3"></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <!-- The original submit button is moved here -->
+                        <button type="submit" class="btn btn-primary">Save Plant</button>
+                    </div>
+                </form> <!-- Form tag ends here -->
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
Corrected an issue where the Bootstrap modal HTML and its form contents were missing or incorrect in index.html, causing JavaScript to fail when trying to find 'plantFormModalElement' and 'getW3wLocationBtn'.

- Restored the proper HTML structure for the Bootstrap modal used for adding and editing plants.
- Ensured that the element IDs ('plantFormModal', 'getW3wLocationBtn') in index.html match the selectors used in script.js.

This change should resolve errors related to these elements not being found and allow the modal functionality to work as intended.