### PR TITLE
feat: Add Area and City/Town fields to plant data

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,19 @@
                                 </button>
                             </div>
                         </div>
+
+                    <!-- ADD NEW FIELDS HERE -->
+                    <div class="mb-3">
+                        <label for="area" class="form-label">Area</label>
+                        <input type="text" class="form-control" id="area" placeholder="e.g. Park, Neighborhood">
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="town" class="form-label">City/Town</label>
+                        <input type="text" class="form-control" id="town" placeholder="e.g. Springfield, Oakland">
+                    </div>
+                    <!-- END OF NEW FIELDS -->
+
                         <div class="mb-3">
                             <label for="ripens" class="form-label">Ripens</label>
                             <input type="text" class="form-control" id="ripens" placeholder="e.g. Late Summer, Year-round">


### PR DESCRIPTION
This commit introduces "Area" and "City/Town" as new data fields for each plant.

Key changes:
- Added "Area" and "City/Town" input fields to the plant form in the modal (index.html).
- Updated script.js:
    - Added DOM references for the new input fields.
    - Modified `handleFormSubmit` to include 'area' and 'town' values (trimmed, with empty strings converted to null) in the data payload for Supabase insert and update operations.
    - Modified `handleEditPlant` to populate the 'Area' and 'City/Town' input fields when loading a plant for editing.
    - Modified `renderPlants` to display 'Area' and 'City/Town' (with "N/A" as fallback for null/empty values) on the plant cards.