### PR TITLE
fix: Refine archive and delete functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -116,11 +116,11 @@ function renderPlants() {
         } else {
             buttonsHTML = `
                 <button class="btn btn-sm btn-info unarchive-btn" data-id="${plant.id}">Unarchive</button>
+                <button class="btn btn-sm btn-danger delete-btn ms-1" data-id="${plant.id}">Delete</button>
             `;
+            // Delete button only for archived plants
         }
-        // Delete button is always available
-        buttonsHTML += ` <button class="btn btn-sm btn-danger delete-btn ms-1" data-id="${plant.id}">Delete</button>`;
-
+        // Note: Delete button is removed from active plants view based on subtask requirement.
 
         const card = `
             <div class="col-md-6 col-lg-4 mb-3">


### PR DESCRIPTION
This commit adjusts the behavior of delete and archive features:
- Active plant cards now only display "Edit" and "Archive" buttons. The direct "Delete" option has been removed from active items.
- Archived plant cards now display "Unarchive" and "Delete" buttons. This allows you to permanently delete items if they are already in an archived state.
- `renderPlants` function updated to reflect these button display rules.
- `attachEventListenersToButtons` and `handleDeletePlant` are maintained to support permanent deletion from the archived view.