### PR TITLE
fix: Clear form after edit to prevent pre-filled 'Add New Plant' modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -213,6 +213,10 @@ async function handleFormSubmit(event) {
                 console.log('Plant updated successfully in Supabase:', data);
                 await loadPlants();
                 if (plantModalInstance) plantModalInstance.hide();
+                // Explicitly reset form state after successful edit
+                plantForm.reset();
+                plantIdInput.value = ''; // Clear the ID from the hidden input
+                if (formTitle) formTitle.textContent = 'Add New Plant'; // Reset title
             }
         } catch (catchError) {
             console.error('Unexpected error updating plant:', catchError);


### PR DESCRIPTION
Corrected a bug where the 'Add New Plant' modal would show data from a previously edited plant.

The `handleFormSubmit` function, in the success path for an update (edit) operation, now explicitly calls `plantForm.reset()`, clears the hidden `plantIdInput`, and resets the `formTitle` after the modal is hidden. This ensures the form is in a clean state before any subsequent modal opening for adding a new plant.